### PR TITLE
Fix library name in error message when git fails

### DIFF
--- a/src/main/clj/cuddlefish/core.clj
+++ b/src/main/clj/cuddlefish/core.clj
@@ -97,7 +97,7 @@
   (let [{:keys [exit out] :as child} (apply sh [git "describe" "--tags" "--dirty" "--long"])]
     (if-not (= exit 0)
       (binding [*out* *err*]
-        (printf "Warning: lein-git-version git exited %d\n%s\n\n"
+        (printf "Warning: cuddlefish git exited %d\n%s\n\n"
                 exit child)
         (.flush *out*)
         {})


### PR DESCRIPTION
Looks like this was a holdover from the lein-git-version days